### PR TITLE
Add the possibility to set any termination character from VISA

### DIFF
--- a/SW/TestAndMeasurement/gpib.c
+++ b/SW/TestAndMeasurement/gpib.c
@@ -408,18 +408,7 @@ char gpib_get_readtermination(void)
 
 void gpib_set_readtermination(char terminator)
 {
-	switch(terminator)
-	{
-		case '\n':
-			s_terminator = '\n';
-			break;
-		case '\r':
-			s_terminator = '\r';
-			break;
-		default:
-			s_terminator = '\0';
-			break;
-	}
+    s_terminator=terminator;
 }
 
 


### PR DESCRIPTION
Add the possibility to set any termination character via the variable `visa.constants.VI_ATTR_TERMCHAR.`
Tested with pyvisa under linux with ni-visa, rs-visa and NI VISA Interactive Control under Windows.
Setting of every character via the !term command is not supprted here, would require changes in the UsbGpibGUI tool and the NiceGUI scripts. If a different character than \cr or \lf gets set, UsbGpibGUI shows an empty field.

the change in
`func = pgm_read_ptr_far((long) &(cmd_list[entryidx]));`
was required in my GCC version, without it it generates an error, with it it's just a warning.

fixes #85